### PR TITLE
Update pocket-home to Debian 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ ifeq ($(WIFI_SUPPORT), 1)
 endif
 ifeq ($(CHIP_FEATURES), 1)
     FEATURE_DEFS := $(FEATURE_DEFS) -DCHIP_FEATURES
+    CONFIG_LDFLAGS += -li2c
 endif
 
 JUCE_CPPFLAGS := $(DEPFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ JUCE_OUTDIR := build
 DATA_PATH := /usr/share/$(JUCE_TARGET_APP)
 
 # Pkg-config libraries:
-PKG_CONFIG_LIBS = NetworkManager libnm-glib alsa freetype2 libssl gio-2.0 \
+PKG_CONFIG_LIBS = libnm alsa freetype2 libssl gio-2.0 \
                   x11 xext xinerama xpm
 
 # Additional library flags:

--- a/Source/Files/Assets/Assets.cpp
+++ b/Source/Files/Assets/Assets.cpp
@@ -85,7 +85,7 @@ juce::Image Assets::loadImageAsset
 
 
 // Creates a Drawable object from an svg asset file.
-juce::Drawable * Assets::loadSVGDrawable
+std::unique_ptr<juce::Drawable> Assets::loadSVGDrawable
 (const juce::String& assetName, bool lookOutsideAssets)
 {
     juce::File svgFile = findAssetFile(assetName, lookOutsideAssets);

--- a/Source/Files/Assets/Assets.h
+++ b/Source/Files/Assets/Assets.h
@@ -58,7 +58,7 @@ namespace Assets
      * @return                   A new drawable if the file was valid, nullptr
      *                           otherwise.
      */
-    juce::Drawable * loadSVGDrawable(const juce::String& assetName,
+    std::unique_ptr<juce::Drawable> loadSVGDrawable(const juce::String& assetName,
             bool lookOutsideAssets = true);
 
     /**

--- a/Source/Files/DesktopEntry/DesktopEntry_FileUtils.cpp
+++ b/Source/Files/DesktopEntry/DesktopEntry_FileUtils.cpp
@@ -378,7 +378,7 @@ juce::String DesktopEntry::FileUtils::boolString(const bool booleanValue)
 
 // Converts a list to a single string that can be written to a desktop entry
 // file.
-juce::String DesktopEntry::FileUtils::listString(const juce::StringArray& list,
+juce::String DesktopEntry::FileUtils::listString(juce::StringArray& list,
         const bool isLocaleString)
 {
     for (juce::String& listItem : list)

--- a/Source/Files/DesktopEntry/DesktopEntry_FileUtils.h
+++ b/Source/Files/DesktopEntry/DesktopEntry_FileUtils.h
@@ -275,7 +275,7 @@ namespace DesktopEntry
          *
          * @return                The list's string representation.
          */
-        juce::String listString(const juce::StringArray& list,
+        juce::String listString(juce::StringArray& list,
                 const bool isLocaleString);
     }
 }

--- a/Source/GUI/Widgets/Widgets_DrawableImage.cpp
+++ b/Source/GUI/Widgets/Widgets_DrawableImage.cpp
@@ -85,7 +85,7 @@ void Widgets::DrawableImage::setImage(const juce::File imageFile)
         {
             removeChildComponent(imageDrawable.get());
         }
-        imageDrawable.reset(juce::Drawable::createFromImageFile(imageFile));
+        imageDrawable = juce::Drawable::createFromImageFile(imageFile);
         if (imageDrawable != nullptr)
         {
             imageSource = imageFile;

--- a/Source/System/Hardware/Hardware_I2CBus.cpp
+++ b/Source/System/Hardware/Hardware_I2CBus.cpp
@@ -2,7 +2,12 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <linux/i2c-dev.h>
+
+extern "C" {
+	#include <linux/i2c.h>
+	#include <linux/i2c-dev.h>
+	#include <i2c/smbus.h>
+}
 
 // Path to the I2C bus device file:
 static constexpr const char* i2cPath = "/dev/i2c-0";


### PR DESCRIPTION
The following changes are needed to get Pocket-Home to work with Debian 11 (here is the image I am using: https://www.reddit.com/r/ChipCommunity/comments/t4k67u/my_attempt_at_a_new_method_of_flashing/).

Note for now I still haven't got wifi to work, but I'm working on it (for now need to compile with "WIFI_SUPPORT=0 make".